### PR TITLE
Fixes based on cargo clippy warnings.

### DIFF
--- a/edpdgen_lib/src/ajdict/input_parsers/dpd.rs
+++ b/edpdgen_lib/src/ajdict/input_parsers/dpd.rs
@@ -31,11 +31,11 @@ impl AjDictPaliWord for DpdPaliWord {
     }
 
     fn sort_key(&self) -> String {
-        make_sort_key(&self.id())
+        make_sort_key(self.id())
     }
 
     fn concise_word_data_entry(&self) -> Result<String, String> {
-        let vm = WordDataViewModel { word: &self };
+        let vm = WordDataViewModel { word: self };
 
         let context = Context::from_serialize(&vm).map_err(|e| e.to_string())?;
         TEMPLATES
@@ -45,7 +45,7 @@ impl AjDictPaliWord for DpdPaliWord {
     }
 
     fn word_data_entry(&self) -> Result<String, String> {
-        let vm = WordDataViewModel { word: &self };
+        let vm = WordDataViewModel { word: self };
 
         let context = Context::from_serialize(&vm).map_err(|e| e.to_string())?;
         TEMPLATES

--- a/edpdgen_lib/src/lib.rs
+++ b/edpdgen_lib/src/lib.rs
@@ -89,8 +89,8 @@ pub fn run(dict_info: &DictionaryInfo, logger: &dyn PlsLogger) -> Result<(), Str
 
     let base_path = create_base_path(
         input_data_path,
-        &dict_info.output_folder,
-        &dict_info.short_name,
+        dict_info.output_folder,
+        dict_info.short_name,
     )?;
     write_dictionary(&base_path, &dict_files, logger)
 }

--- a/edpdgen_lib/src/stardict/input_parsers/dpd.rs
+++ b/edpdgen_lib/src/stardict/input_parsers/dpd.rs
@@ -40,15 +40,15 @@ impl StarDictPaliWord for DpdPaliWord {
     }
 
     fn sort_key(&self) -> String {
-        make_sort_key(&self.id())
+        make_sort_key(self.id())
     }
 
     fn group_id(&self) -> String {
-        make_group_id(&self.id())
+        make_group_id(self.id())
     }
 
     fn toc_id(&self, dict_short_name: &str) -> String {
-        make_toc_id(&self.id(), dict_short_name)
+        make_toc_id(self.id(), dict_short_name)
     }
 
     fn toc_entry(&self, dict_short_name: &str, concise: bool) -> Result<String, String> {
@@ -80,7 +80,7 @@ impl StarDictPaliWord for DpdPaliWord {
             Ok("".to_string())
         } else {
             let vm = WordDataViewModel {
-                word: &self,
+                word: self,
                 toc_id: &self.toc_id(dict_short_name),
                 dict_short_name,
                 feedback_form_url,

--- a/edpdgen_lib/src/stardict/input_parsers/dps.rs
+++ b/edpdgen_lib/src/stardict/input_parsers/dps.rs
@@ -40,15 +40,15 @@ impl StarDictPaliWord for DpsPaliWord {
     }
 
     fn sort_key(&self) -> String {
-        make_sort_key(&self.id())
+        make_sort_key(self.id())
     }
 
     fn group_id(&self) -> String {
-        make_group_id(&self.id())
+        make_group_id(self.id())
     }
 
     fn toc_id(&self, dict_short_name: &str) -> String {
-        make_toc_id(&self.id(), dict_short_name)
+        make_toc_id(self.id(), dict_short_name)
     }
 
     fn toc_entry(&self, dict_short_name: &str, concise: bool) -> Result<String, String> {
@@ -77,7 +77,7 @@ impl StarDictPaliWord for DpsPaliWord {
             Ok("".to_string())
         } else {
             let vm = WordDataViewModel {
-                word: &self,
+                word: self,
                 toc_id: &self.toc_id(dict_short_name),
                 dict_short_name,
                 feedback_form_url,

--- a/edpdgen_lib/src/stardict/mod.rs
+++ b/edpdgen_lib/src/stardict/mod.rs
@@ -73,7 +73,7 @@ pub fn run_for_ods_type<'a, T: 'a + serde::de::DeserializeOwned + StarDictPaliWo
     logger: &dyn PlsLogger,
 ) -> Result<Vec<DictionaryFile>, String> {
     let words = input_parsers::load_words::<T>(input_data_path, logger)?;
-    let sd_files = output_generators::create_dictionary(&dict_info, words, igen, logger)?;
+    let sd_files = output_generators::create_dictionary(dict_info, words, igen, logger)?;
 
     Ok(sd_files)
 }

--- a/edpdgen_lib/src/stardict/output_generators/mod.rs
+++ b/edpdgen_lib/src/stardict/output_generators/mod.rs
@@ -74,10 +74,10 @@ fn get_ids_and_html_for_word_group(
             (
                 w.sort_key(),
                 w.id().to_string(),
-                w.toc_entry(&dict_info.short_name, dict_info.concise)
+                w.toc_entry(dict_info.short_name, dict_info.concise)
                     .unwrap_or_else(|e| log_return_error(&w, "table of contents", e, logger)),
                 w.word_data_entry(
-                    &dict_info.short_name,
+                    dict_info.short_name,
                     dict_info.feedback_form_url,
                     dict_info.host_url,
                     dict_info.host_version,
@@ -101,7 +101,7 @@ fn get_ids_and_html_for_word_group(
             });
 
     let vm = WordGroupViewModel {
-        dict_short_name: &dict_info.short_name,
+        dict_short_name: dict_info.short_name,
         headings_color: dict_info.headings_color,
         links_color: dict_info.links_color,
         toc_entries: &toc_entries,


### PR DESCRIPTION
Warnings due to ```borrowing a reference that is immediately dereferenced by the compiler```.